### PR TITLE
FIX: missing endblock tag </div>

### DIFF
--- a/src/viewer/tutorials/shortcuts.md
+++ b/src/viewer/tutorials/shortcuts.md
@@ -77,7 +77,7 @@ const component1 = {
                     <p><b>Listen to local context shortcuts :</b></p>
                     <p>{{ localMessage || "..." }}</p>
                   </div>
-                <div>
+                </div>
               </div>`,
 };
 ```
@@ -158,7 +158,7 @@ const component1 = {
                     <p><b>Listen to local context shortcuts :</b></p>
                     <p>{{ localMessage || "..." }}</p>
                   </div>
-                <div>
+                </div>
               </div>`,
 };
 


### PR DESCRIPTION
I'm following your documentation, the copied template for the component 1 has missing endblock tags.